### PR TITLE
updated logic for left/right check, removed double calculation of margin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Platform](https://img.shields.io/badge/platform-android-green.svg)](http://developer.android.com/index.html)
 ![SDK](https://img.shields.io/badge/SDK-16%2B-green.svg)
-![Release](https://img.shields.io/badge/release-0.0.10-green.svg)
+![Release](https://img.shields.io/badge/release-0.0.11-green.svg)
 [![Jitpack](https://jitpack.io/v/myntra/CoachMarks.svg)](https://jitpack.io/#myntra/CoachMarks)
 [![Build Status](https://travis-ci.org/myntra/CoachMarks.svg?branch=master)](https://travis-ci.org/myntra/CoachMarks)
 [![CircleCI](https://circleci.com/gh/myntra/CoachMarks.svg?style=svg)](https://circleci.com/gh/myntra/CoachMarks)
@@ -23,7 +23,7 @@ Add jitpack to your root `build.gradle`
 Add the dependency
 ```
 	dependencies {
-	        compile 'com.github.myntra:CoachMarks:0.0.10'
+	        compile 'com.github.myntra:CoachMarks:0.0.11'
 	}
 ```
 

--- a/coachmarks/build.gradle
+++ b/coachmarks/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
         versionCode 1
-        versionName "0.0.10"
+        versionName "0.0.11"
         vectorDrawables.useSupportLibrary = true
     }
 

--- a/coachmarks/src/main/java/com/myntra/coachmarks/ui/presenter/PopUpCoachMarkPresenter.java
+++ b/coachmarks/src/main/java/com/myntra/coachmarks/ui/presenter/PopUpCoachMarkPresenter.java
@@ -127,6 +127,7 @@ public class PopUpCoachMarkPresenter {
                 mCoachMarkBuilder.getAnchorTop().y,
                 mCoachMarkBuilder.getAnchorBottom().y,
                 mCoachMarkBuilder.getAnchorTop().x,
+                mCoachMarkBuilder.getAnchorBottom().x,
                 coachMarkDimenInPixel);
         detectAndCreateShimOutViews(mCoachMarkBuilder.getInfoForViewToMaskList());
         setImageParamsAndPosition(mCoachMarkBuilder.getAnchorTop(),
@@ -183,11 +184,13 @@ public class PopUpCoachMarkPresenter {
                                      int anchorTopY,
                                      int anchorBottomY,
                                      int anchorTopX,
+                                     int anchorBottomX,
                                      CoachMarkPixelInfo coachMarkDimenInPixel) {
         int notchPosition;
         int actualTopMargin;
         int actualLeftMargin;
         int centerY = (anchorTopY + anchorBottomY) / 2;
+        int centerX = (anchorTopX + anchorBottomX) / 2;
 
         Rect notchMarginRect;
         Rect coachMarkMarginRect;
@@ -436,9 +439,7 @@ public class PopUpCoachMarkPresenter {
     private boolean checkIfLeftPossible(Point viewCenterPoint,
                                         CoachMarkPixelInfo coachMarkDimenInPixel) {
         int centerX = viewCenterPoint.x;
-        return (coachMarkDimenInPixel.getPopUpWidthInPixelsWithOffset() +
-                coachMarkDimenInPixel.getMarginRectInPixels().right +
-                coachMarkDimenInPixel.getMarginRectInPixels().left) < centerX &&
+        return (coachMarkDimenInPixel.getPopUpWidthInPixelsWithOffset()) < centerX &&
                 ((coachMarkDimenInPixel.getPopUpHeightInPixelsWithOffset() +
                         coachMarkDimenInPixel.getMarginRectInPixels().top +
                         coachMarkDimenInPixel.getActionBarHeightPixels() +
@@ -450,9 +451,7 @@ public class PopUpCoachMarkPresenter {
     private boolean checkIfRightPossible(Point viewCenterPoint,
                                          CoachMarkPixelInfo coachMarkDimenInPixel) {
         int centerX = viewCenterPoint.x;
-        return (coachMarkDimenInPixel.getPopUpWidthInPixelsWithOffset() +
-                coachMarkDimenInPixel.getMarginRectInPixels().right +
-                coachMarkDimenInPixel.getMarginRectInPixels().left) <=
+        return (coachMarkDimenInPixel.getPopUpWidthInPixelsWithOffset()) <=
                 (coachMarkDimenInPixel.getScreenWidthInPixels() - centerX) &&
                 ((coachMarkDimenInPixel.getPopUpHeightInPixelsWithOffset() +
                         coachMarkDimenInPixel.getMarginRectInPixels().top +

--- a/coachmarks/src/main/java/com/myntra/coachmarks/ui/presenter/PopUpCoachMarkPresenter.java
+++ b/coachmarks/src/main/java/com/myntra/coachmarks/ui/presenter/PopUpCoachMarkPresenter.java
@@ -38,7 +38,6 @@ public class PopUpCoachMarkPresenter {
 
     private static final double MAX_NOTCH_RANGE = .85;
     private static final double MIN_NOTCH_RANGE = 0.0;
-    private static final double DEFAULT_NOTCH_VALUE_WIDTH = .20;
 
     private static final int NO_MARGIN = 0;
 
@@ -60,8 +59,6 @@ public class PopUpCoachMarkPresenter {
     private IScreenInfoProvider mScreenInfoProvider;
     private IStringResourceProvider mStringResourceProvider;
     private IDimensionResourceProvider mDimensionResourceProvider;
-
-    private boolean mDefaultPopUpLocationFailed = false;
 
     public PopUpCoachMarkPresenter(final IStringResourceProvider stringResourceProvider,
                                    final IDimensionResourceProvider dimensionResourceProvider,
@@ -204,48 +201,28 @@ public class PopUpCoachMarkPresenter {
                         coachMarkDimenInPixel.getMarginRectInPixels().right +
                                 coachMarkDimenInPixel.getImageWidthInPixels(),
                         NO_MARGIN);
-
+                mPresentation.setPopUpViewTopLeft(coachMarkMarginRect,
+                        CoachMarkLayoutOrientation.HORIZONTAL);
                 notchPosition = getMarginTopForNotch(mCoachMarkBuilder.getNotchPosition(),
                         coachMarkDimenInPixel.getPopUpHeightInPixels(),
                         coachMarkDimenInPixel.getNotchDimenInPixels());
-
-                mPresentation.setPopUpViewTopLeft(coachMarkMarginRect,
-                        CoachMarkLayoutOrientation.HORIZONTAL);
-
                 notchMarginRect = new Rect(-coachMarkDimenInPixel.getMarginOffsetForNotchInPixels(),
                         notchPosition, NO_MARGIN, NO_MARGIN);
                 mPresentation.setNotchPositionIfPopUpTopLeft(notchMarginRect, ROTATION_90);
                 break;
             case PopUpPosition.TOP:
                 actualLeftMargin = getActualLeftMargin(anchorTopX, coachMarkDimenInPixel);
-
-                if(! mDefaultPopUpLocationFailed){
-                    coachMarkMarginRect = new Rect(actualLeftMargin -
-                            coachMarkDimenInPixel.getMarginRectInPixels().right,
-                            coachMarkDimenInPixel.getMarginRectInPixels().top,
-                            NO_MARGIN,
-                            coachMarkDimenInPixel.getMarginRectInPixels().bottom +
-                                    coachMarkDimenInPixel.getImageHeightInPixels());
-                    notchPosition = getMarginLeftForNotch(mCoachMarkBuilder.getNotchPosition(),
-                            coachMarkDimenInPixel.getPopUpWidthInPixels(),
-                            coachMarkDimenInPixel.getNotchDimenInPixels());
-                }else{
-
-                    coachMarkMarginRect = new Rect(actualLeftMargin -
-                            coachMarkDimenInPixel.getMarginRectInPixels().right,
-                            coachMarkDimenInPixel.getMarginRectInPixels().top,
-                            NO_MARGIN,
-                            coachMarkDimenInPixel.getImageHeightInPixels());
-
-                    notchPosition = getMarginLeftForNotch(DEFAULT_NOTCH_VALUE_WIDTH,
-                            coachMarkDimenInPixel.getPopUpWidthInPixels(),
-                            coachMarkDimenInPixel.getNotchDimenInPixels());
-
-                }
-
+                coachMarkMarginRect = new Rect(actualLeftMargin -
+                        coachMarkDimenInPixel.getMarginRectInPixels().right,
+                        coachMarkDimenInPixel.getMarginRectInPixels().top,
+                        NO_MARGIN,
+                        coachMarkDimenInPixel.getMarginRectInPixels().bottom +
+                                coachMarkDimenInPixel.getImageHeightInPixels());
                 mPresentation.setPopUpViewTopLeft(coachMarkMarginRect,
                         CoachMarkLayoutOrientation.VERTICAL);
-
+                notchPosition = getMarginLeftForNotch(mCoachMarkBuilder.getNotchPosition(),
+                        coachMarkDimenInPixel.getPopUpWidthInPixels(),
+                        coachMarkDimenInPixel.getNotchDimenInPixels());
                 notchMarginRect = new Rect(notchPosition +
                         coachMarkDimenInPixel.getMarginOffsetForNotchInPixels(),
                         -coachMarkDimenInPixel.getMarginOffsetForNotchInPixels(),
@@ -254,20 +231,16 @@ public class PopUpCoachMarkPresenter {
                 break;
             case PopUpPosition.RIGHT:
                 actualTopMargin = getActualTopMargin(centerY, coachMarkDimenInPixel);
-
                 coachMarkMarginRect = new Rect(coachMarkDimenInPixel.getMarginRectInPixels().left +
                         coachMarkDimenInPixel.getImageWidthInPixels(),
                         actualTopMargin - coachMarkDimenInPixel.getMarginRectInPixels().bottom,
                         coachMarkDimenInPixel.getMarginRectInPixels().right,
                         NO_MARGIN);
-
+                mPresentation.setPopUpViewBottomRight(coachMarkMarginRect,
+                        CoachMarkLayoutOrientation.HORIZONTAL);
                 notchPosition = getMarginTopForNotch(mCoachMarkBuilder.getNotchPosition(),
                         coachMarkDimenInPixel.getPopUpHeightInPixels(),
                         coachMarkDimenInPixel.getNotchDimenInPixels());
-
-                mPresentation.setPopUpViewBottomRight(coachMarkMarginRect,
-                        CoachMarkLayoutOrientation.HORIZONTAL);
-
                 notchMarginRect = new Rect(NO_MARGIN,
                         notchPosition - (int) (MULTIPLICATION_FACTOR_NOTCH_POSITION * coachMarkDimenInPixel.getMarginOffsetForNotchInPixels()),
                         NO_MARGIN,
@@ -281,36 +254,17 @@ public class PopUpCoachMarkPresenter {
                 break;
             case PopUpPosition.BOTTOM:
                 actualLeftMargin = getActualLeftMargin(anchorTopX, coachMarkDimenInPixel);
-                if(! mDefaultPopUpLocationFailed){
-
-                    coachMarkMarginRect = new Rect(actualLeftMargin -
-                            coachMarkDimenInPixel.getMarginRectInPixels().right,
-                            coachMarkDimenInPixel.getMarginRectInPixels().top +
-                                    coachMarkDimenInPixel.getImageHeightInPixels(),
-                            NO_MARGIN,
-                            coachMarkDimenInPixel.getMarginRectInPixels().bottom);
-
-                    notchPosition = getMarginLeftForNotch(mCoachMarkBuilder.getNotchPosition(),
-                            coachMarkDimenInPixel.getPopUpWidthInPixels(),
-                            coachMarkDimenInPixel.getNotchDimenInPixels());
-
-                }else{
-
-                    coachMarkMarginRect = new Rect(actualLeftMargin -
-                            coachMarkDimenInPixel.getMarginRectInPixels().right,
-                            coachMarkDimenInPixel.getImageHeightInPixels(),
-                            NO_MARGIN,
-                            coachMarkDimenInPixel.getMarginRectInPixels().bottom);
-
-                    notchPosition = getMarginLeftForNotch(DEFAULT_NOTCH_VALUE_WIDTH,
-                            coachMarkDimenInPixel.getPopUpWidthInPixels(),
-                            coachMarkDimenInPixel.getNotchDimenInPixels());
-
-                }
-
+                coachMarkMarginRect = new Rect(actualLeftMargin -
+                        coachMarkDimenInPixel.getMarginRectInPixels().right,
+                        coachMarkDimenInPixel.getMarginRectInPixels().top +
+                                coachMarkDimenInPixel.getImageHeightInPixels(),
+                        NO_MARGIN,
+                        coachMarkDimenInPixel.getMarginRectInPixels().bottom);
                 mPresentation.setPopUpViewBottomRight(coachMarkMarginRect,
                         CoachMarkLayoutOrientation.VERTICAL);
-
+                notchPosition = getMarginLeftForNotch(mCoachMarkBuilder.getNotchPosition(),
+                        coachMarkDimenInPixel.getPopUpWidthInPixels(),
+                        coachMarkDimenInPixel.getNotchDimenInPixels());
                 notchMarginRect = new Rect(notchPosition +
                         coachMarkDimenInPixel.getMarginOffsetForNotchInPixels(),
                         NO_MARGIN,
@@ -442,7 +396,6 @@ public class PopUpCoachMarkPresenter {
                 } else {
                     correctPosition = getCorrectPositionOfCoachMarkIfDefaultFails(viewCenterPoint,
                             coachMarkDimenInPixel);
-                    mDefaultPopUpLocationFailed = true;
                 }
                 break;
             case PopUpPosition.RIGHT:
@@ -451,7 +404,6 @@ public class PopUpCoachMarkPresenter {
                 } else {
                     correctPosition = getCorrectPositionOfCoachMarkIfDefaultFails(viewCenterPoint,
                             coachMarkDimenInPixel);
-                    mDefaultPopUpLocationFailed = true;
                 }
                 break;
 
@@ -461,7 +413,6 @@ public class PopUpCoachMarkPresenter {
                 } else {
                     correctPosition = getCorrectPositionOfCoachMarkIfDefaultFails(viewCenterPoint,
                             coachMarkDimenInPixel);
-                    mDefaultPopUpLocationFailed = true;
                 }
                 break;
 
@@ -471,14 +422,12 @@ public class PopUpCoachMarkPresenter {
                 } else {
                     correctPosition = getCorrectPositionOfCoachMarkIfDefaultFails(viewCenterPoint,
                             coachMarkDimenInPixel);
-                    mDefaultPopUpLocationFailed = true;
                 }
                 break;
             case PopUpPosition.NONE:
                 //if user selects no position by default check clockwise to find the correct position
                 correctPosition = getCorrectPositionOfCoachMarkIfDefaultFails(viewCenterPoint,
                         coachMarkDimenInPixel);
-
                 break;
         }
         return correctPosition;

--- a/coachmarks/src/main/java/com/myntra/coachmarks/ui/presenter/PopUpCoachMarkPresenter.java
+++ b/coachmarks/src/main/java/com/myntra/coachmarks/ui/presenter/PopUpCoachMarkPresenter.java
@@ -38,6 +38,7 @@ public class PopUpCoachMarkPresenter {
 
     private static final double MAX_NOTCH_RANGE = .85;
     private static final double MIN_NOTCH_RANGE = 0.0;
+    private static final double DEFAULT_NOTCH_VALUE_WIDTH = .20;
 
     private static final int NO_MARGIN = 0;
 
@@ -59,6 +60,8 @@ public class PopUpCoachMarkPresenter {
     private IScreenInfoProvider mScreenInfoProvider;
     private IStringResourceProvider mStringResourceProvider;
     private IDimensionResourceProvider mDimensionResourceProvider;
+
+    private boolean mDefaultPopUpLocationFailed = false;
 
     public PopUpCoachMarkPresenter(final IStringResourceProvider stringResourceProvider,
                                    final IDimensionResourceProvider dimensionResourceProvider,
@@ -201,28 +204,48 @@ public class PopUpCoachMarkPresenter {
                         coachMarkDimenInPixel.getMarginRectInPixels().right +
                                 coachMarkDimenInPixel.getImageWidthInPixels(),
                         NO_MARGIN);
-                mPresentation.setPopUpViewTopLeft(coachMarkMarginRect,
-                        CoachMarkLayoutOrientation.HORIZONTAL);
+
                 notchPosition = getMarginTopForNotch(mCoachMarkBuilder.getNotchPosition(),
                         coachMarkDimenInPixel.getPopUpHeightInPixels(),
                         coachMarkDimenInPixel.getNotchDimenInPixels());
+
+                mPresentation.setPopUpViewTopLeft(coachMarkMarginRect,
+                        CoachMarkLayoutOrientation.HORIZONTAL);
+
                 notchMarginRect = new Rect(-coachMarkDimenInPixel.getMarginOffsetForNotchInPixels(),
                         notchPosition, NO_MARGIN, NO_MARGIN);
                 mPresentation.setNotchPositionIfPopUpTopLeft(notchMarginRect, ROTATION_90);
                 break;
             case PopUpPosition.TOP:
                 actualLeftMargin = getActualLeftMargin(anchorTopX, coachMarkDimenInPixel);
-                coachMarkMarginRect = new Rect(actualLeftMargin -
-                        coachMarkDimenInPixel.getMarginRectInPixels().right,
-                        coachMarkDimenInPixel.getMarginRectInPixels().top,
-                        NO_MARGIN,
-                        coachMarkDimenInPixel.getMarginRectInPixels().bottom +
-                                coachMarkDimenInPixel.getImageHeightInPixels());
+
+                if(! mDefaultPopUpLocationFailed){
+                    coachMarkMarginRect = new Rect(actualLeftMargin -
+                            coachMarkDimenInPixel.getMarginRectInPixels().right,
+                            coachMarkDimenInPixel.getMarginRectInPixels().top,
+                            NO_MARGIN,
+                            coachMarkDimenInPixel.getMarginRectInPixels().bottom +
+                                    coachMarkDimenInPixel.getImageHeightInPixels());
+                    notchPosition = getMarginLeftForNotch(mCoachMarkBuilder.getNotchPosition(),
+                            coachMarkDimenInPixel.getPopUpWidthInPixels(),
+                            coachMarkDimenInPixel.getNotchDimenInPixels());
+                }else{
+
+                    coachMarkMarginRect = new Rect(actualLeftMargin -
+                            coachMarkDimenInPixel.getMarginRectInPixels().right,
+                            coachMarkDimenInPixel.getMarginRectInPixels().top,
+                            NO_MARGIN,
+                            coachMarkDimenInPixel.getImageHeightInPixels());
+
+                    notchPosition = getMarginLeftForNotch(DEFAULT_NOTCH_VALUE_WIDTH,
+                            coachMarkDimenInPixel.getPopUpWidthInPixels(),
+                            coachMarkDimenInPixel.getNotchDimenInPixels());
+
+                }
+
                 mPresentation.setPopUpViewTopLeft(coachMarkMarginRect,
                         CoachMarkLayoutOrientation.VERTICAL);
-                notchPosition = getMarginLeftForNotch(mCoachMarkBuilder.getNotchPosition(),
-                        coachMarkDimenInPixel.getPopUpWidthInPixels(),
-                        coachMarkDimenInPixel.getNotchDimenInPixels());
+
                 notchMarginRect = new Rect(notchPosition +
                         coachMarkDimenInPixel.getMarginOffsetForNotchInPixels(),
                         -coachMarkDimenInPixel.getMarginOffsetForNotchInPixels(),
@@ -231,16 +254,20 @@ public class PopUpCoachMarkPresenter {
                 break;
             case PopUpPosition.RIGHT:
                 actualTopMargin = getActualTopMargin(centerY, coachMarkDimenInPixel);
+
                 coachMarkMarginRect = new Rect(coachMarkDimenInPixel.getMarginRectInPixels().left +
                         coachMarkDimenInPixel.getImageWidthInPixels(),
                         actualTopMargin - coachMarkDimenInPixel.getMarginRectInPixels().bottom,
                         coachMarkDimenInPixel.getMarginRectInPixels().right,
                         NO_MARGIN);
-                mPresentation.setPopUpViewBottomRight(coachMarkMarginRect,
-                        CoachMarkLayoutOrientation.HORIZONTAL);
+
                 notchPosition = getMarginTopForNotch(mCoachMarkBuilder.getNotchPosition(),
                         coachMarkDimenInPixel.getPopUpHeightInPixels(),
                         coachMarkDimenInPixel.getNotchDimenInPixels());
+
+                mPresentation.setPopUpViewBottomRight(coachMarkMarginRect,
+                        CoachMarkLayoutOrientation.HORIZONTAL);
+
                 notchMarginRect = new Rect(NO_MARGIN,
                         notchPosition - (int) (MULTIPLICATION_FACTOR_NOTCH_POSITION * coachMarkDimenInPixel.getMarginOffsetForNotchInPixels()),
                         NO_MARGIN,
@@ -254,17 +281,36 @@ public class PopUpCoachMarkPresenter {
                 break;
             case PopUpPosition.BOTTOM:
                 actualLeftMargin = getActualLeftMargin(anchorTopX, coachMarkDimenInPixel);
-                coachMarkMarginRect = new Rect(actualLeftMargin -
-                        coachMarkDimenInPixel.getMarginRectInPixels().right,
-                        coachMarkDimenInPixel.getMarginRectInPixels().top +
-                                coachMarkDimenInPixel.getImageHeightInPixels(),
-                        NO_MARGIN,
-                        coachMarkDimenInPixel.getMarginRectInPixels().bottom);
+                if(! mDefaultPopUpLocationFailed){
+
+                    coachMarkMarginRect = new Rect(actualLeftMargin -
+                            coachMarkDimenInPixel.getMarginRectInPixels().right,
+                            coachMarkDimenInPixel.getMarginRectInPixels().top +
+                                    coachMarkDimenInPixel.getImageHeightInPixels(),
+                            NO_MARGIN,
+                            coachMarkDimenInPixel.getMarginRectInPixels().bottom);
+
+                    notchPosition = getMarginLeftForNotch(mCoachMarkBuilder.getNotchPosition(),
+                            coachMarkDimenInPixel.getPopUpWidthInPixels(),
+                            coachMarkDimenInPixel.getNotchDimenInPixels());
+
+                }else{
+
+                    coachMarkMarginRect = new Rect(actualLeftMargin -
+                            coachMarkDimenInPixel.getMarginRectInPixels().right,
+                            coachMarkDimenInPixel.getImageHeightInPixels(),
+                            NO_MARGIN,
+                            coachMarkDimenInPixel.getMarginRectInPixels().bottom);
+
+                    notchPosition = getMarginLeftForNotch(DEFAULT_NOTCH_VALUE_WIDTH,
+                            coachMarkDimenInPixel.getPopUpWidthInPixels(),
+                            coachMarkDimenInPixel.getNotchDimenInPixels());
+
+                }
+
                 mPresentation.setPopUpViewBottomRight(coachMarkMarginRect,
                         CoachMarkLayoutOrientation.VERTICAL);
-                notchPosition = getMarginLeftForNotch(mCoachMarkBuilder.getNotchPosition(),
-                        coachMarkDimenInPixel.getPopUpWidthInPixels(),
-                        coachMarkDimenInPixel.getNotchDimenInPixels());
+
                 notchMarginRect = new Rect(notchPosition +
                         coachMarkDimenInPixel.getMarginOffsetForNotchInPixels(),
                         NO_MARGIN,
@@ -396,6 +442,7 @@ public class PopUpCoachMarkPresenter {
                 } else {
                     correctPosition = getCorrectPositionOfCoachMarkIfDefaultFails(viewCenterPoint,
                             coachMarkDimenInPixel);
+                    mDefaultPopUpLocationFailed = true;
                 }
                 break;
             case PopUpPosition.RIGHT:
@@ -404,6 +451,7 @@ public class PopUpCoachMarkPresenter {
                 } else {
                     correctPosition = getCorrectPositionOfCoachMarkIfDefaultFails(viewCenterPoint,
                             coachMarkDimenInPixel);
+                    mDefaultPopUpLocationFailed = true;
                 }
                 break;
 
@@ -413,6 +461,7 @@ public class PopUpCoachMarkPresenter {
                 } else {
                     correctPosition = getCorrectPositionOfCoachMarkIfDefaultFails(viewCenterPoint,
                             coachMarkDimenInPixel);
+                    mDefaultPopUpLocationFailed = true;
                 }
                 break;
 
@@ -422,12 +471,14 @@ public class PopUpCoachMarkPresenter {
                 } else {
                     correctPosition = getCorrectPositionOfCoachMarkIfDefaultFails(viewCenterPoint,
                             coachMarkDimenInPixel);
+                    mDefaultPopUpLocationFailed = true;
                 }
                 break;
             case PopUpPosition.NONE:
                 //if user selects no position by default check clockwise to find the correct position
                 correctPosition = getCorrectPositionOfCoachMarkIfDefaultFails(viewCenterPoint,
                         coachMarkDimenInPixel);
+
                 break;
         }
         return correctPosition;

--- a/coachmarks/src/main/java/com/myntra/coachmarks/ui/presenter/PopUpCoachMarkPresenter.java
+++ b/coachmarks/src/main/java/com/myntra/coachmarks/ui/presenter/PopUpCoachMarkPresenter.java
@@ -127,7 +127,6 @@ public class PopUpCoachMarkPresenter {
                 mCoachMarkBuilder.getAnchorTop().y,
                 mCoachMarkBuilder.getAnchorBottom().y,
                 mCoachMarkBuilder.getAnchorTop().x,
-                mCoachMarkBuilder.getAnchorBottom().x,
                 coachMarkDimenInPixel);
         detectAndCreateShimOutViews(mCoachMarkBuilder.getInfoForViewToMaskList());
         setImageParamsAndPosition(mCoachMarkBuilder.getAnchorTop(),
@@ -184,13 +183,11 @@ public class PopUpCoachMarkPresenter {
                                      int anchorTopY,
                                      int anchorBottomY,
                                      int anchorTopX,
-                                     int anchorBottomX,
                                      CoachMarkPixelInfo coachMarkDimenInPixel) {
         int notchPosition;
         int actualTopMargin;
         int actualLeftMargin;
         int centerY = (anchorTopY + anchorBottomY) / 2;
-        int centerX = (anchorTopX + anchorBottomX) / 2;
 
         Rect notchMarginRect;
         Rect coachMarkMarginRect;

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
         versionCode 1
-        versionName "0.0.10"
+        versionName "0.0.11"
     }
 
     buildTypes {


### PR DESCRIPTION
* Updated logic for left/right position check
* Calculation was happening twice for left/right margins. Its now fixed.
* Tested with moto razor and nexus 5 with 500 something width. Works fine now.
* Bump version to 0.0.11.
* Fixed logic to use deafult values if user defined position fails in case of left/right
* Checked and supported devices till 480 width