### PR TITLE
The cache of Travis CI can improve build performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,5 +56,8 @@ notifications:
   email: true
   slack: myntra:3GgFvhHOLMEe3WIVzuoFUW8Y
 
-cache: false
+cache:
+   directories:
+   - $HOME/.gradle/caches/
+   - $HOME/.gradle/wrapper/
 sudo: required


### PR DESCRIPTION
[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.
